### PR TITLE
Cytoscape demo optionally collects data from Graph plugins.

### DIFF
--- a/client/cytodemo.coffee
+++ b/client/cytodemo.coffee
@@ -108,6 +108,23 @@ emit = ($item, item) ->
     page = $item.parents '.page' unless e.shiftKey
     wiki.doInternalLink node.id(), page
 
+  cy.on 'mouseover', 'node', (e) ->
+        e.cyTarget.style {
+          'border-width': 2,
+          'border-color': '#D84315',
+          'font-size' : (d) ->
+            size = Number(d.css("font-size").slice(0, -2))+10
+            size + "px"
+        }
+
+  cy.on 'mouseout', 'node',(e) ->
+        e.cyTarget.style {
+          'border-width': 0,
+          'font-size' : (d) ->
+            size = Number(d.css("font-size").slice(0, -2))-10
+            size + "px"
+        }
+
   # create a lightbox to display fullscreen
   $lightbox = $ '<div id="lightbox"></div>'
   $lightbox.css {

--- a/client/cytodemo.coffee
+++ b/client/cytodemo.coffee
@@ -49,11 +49,16 @@ elements = ($item, item) ->
   dataNodes = -> ({data: {id: n}} for n,v of nodes)
   {nodes: dataNodes(), edges: dataEdges()}
 
+block = (event) ->
+  event.preventDefault()
+  event.stopPropagation()
+
 emit = ($item, item) ->
   $cy = $ '<div style="position: relative; width: 420px; height: 420px; border: 1px solid #ccc;"></div>'
-
   $item.append $cy
   $item.append '<p>Learn more about <a href="http://js.cytoscape.org">Cytoscape</a>.</p>'
+  $cy.on 'mousedown', block
+  $cy.on 'tapped', block
 
   cy = cytoscape {
     container: $cy,

--- a/client/cytodemo.coffee
+++ b/client/cytodemo.coffee
@@ -2,7 +2,7 @@ cytoscape = require 'cytoscape'
 dagre = require 'dagre'
 cydagre = require 'cytoscape-dagre' # dagre ext for cytoscape (https://github.com/cytoscape/cytoscape.js-dagre)
 
-cydagre cytoscape dagre # register cy-dagre ext w/ cytoscape
+cydagre cytoscape, dagre
 
 emit = ($item, item) ->
   $cy = $ '<div style="position: relative; width: 420px; height: 420px; border: 1px solid #ccc;"></div>'

--- a/client/cytodemo.coffee
+++ b/client/cytodemo.coffee
@@ -89,6 +89,7 @@ emit = ($item, item) ->
       {
         selector: 'edge',
         style: {
+          'curve-style': 'bezier',
           'width': 2 ,
           'target-arrow-shape': 'triangle',
           'line-color' : '#9dbaea',
@@ -108,22 +109,25 @@ emit = ($item, item) ->
     page = $item.parents '.page' unless e.shiftKey
     wiki.doInternalLink node.id(), page
 
-  cy.on 'mouseover', 'node', (e) ->
-        e.cyTarget.style {
-          'border-width': 2,
-          'border-color': '#D84315',
-          'font-size' : (d) ->
-            size = Number(d.css("font-size").slice(0, -2))+10
-            size + "px"
-        }
+  applyGraphMouseBehaviors = (graph) ->
+    graph.on 'mouseover', 'node', (e) ->
+          e.cyTarget.style {
+            'border-width': 2,
+            'border-color': '#D84315',
+            'font-size' : (d) ->
+              size = Number(d.css("font-size").slice(0, -2))+10
+              size + "px"
+          }
 
-  cy.on 'mouseout', 'node',(e) ->
-        e.cyTarget.style {
-          'border-width': 0,
-          'font-size' : (d) ->
-            size = Number(d.css("font-size").slice(0, -2))-10
-            size + "px"
-        }
+    graph.on 'mouseout', 'node',(e) ->
+          e.cyTarget.style {
+            'border-width': 0,
+            'font-size' : (d) ->
+              size = Number(d.css("font-size").slice(0, -2))-10
+              size + "px"
+          }
+
+  applyGraphMouseBehaviors(cy)
 
   # create a lightbox to display fullscreen
   $lightbox = $ '<div id="lightbox"></div>'
@@ -158,6 +162,7 @@ emit = ($item, item) ->
     e.preventDefault()
     options.container = $cyfullscreen
     cyfullscreen = cytoscape options
+    # applyGraphMouseBehaviors(cyfullscreen)
     console.log cyfullscreen
     $lightbox.show()
 

--- a/client/cytodemo.coffee
+++ b/client/cytodemo.coffee
@@ -54,14 +54,20 @@ block = (event) ->
   event.stopPropagation()
 
 emit = ($item, item) ->
-  $cy = $ '<div style="position: relative; width: 420px; height: 420px; border: 1px solid #ccc;"></div>'
+  $cy = $ '<div class="cytowiki" style="position: relative; width: 420px; height: 420px; border: 1px solid #ccc;"></div>'
   $item.append $cy
-  $item.append '<p>Learn more about <a href="http://js.cytoscape.org">Cytoscape</a>.</p>'
+
+  #
+  $caption = $ '<p></p>'
+  $caption.append 'Learn more about <a href="http://js.cytoscape.org">Cytoscape</a>.'
+  $fullscreenlink =  $ '<span> - <a id="cy-fullscreen" href="#">Full Screen</a>.</span>'
+  $caption.append $fullscreenlink
+  $item.append $caption
+
   $cy.on 'mousedown', block
   $cy.on 'tapped', block
 
-  cy = cytoscape {
-    container: $cy,
+  options = {
     layout: { name: 'dagre' },
     boxSelectionEnabled: false,
     autounselectify: true,
@@ -89,11 +95,49 @@ emit = ($item, item) ->
     elements: elements($item,item)
   }
 
+  options.container = $cy
+  cy = cytoscape options
+
   cy.on 'click', 'node', (e) ->
     node = e.cyTarget;
     page = $item.parents '.page' unless e.shiftKey
     wiki.doInternalLink node.id(), page
 
+  # create a lightbox to display fullscreen
+  $lightbox = $ '<div id="lightbox"></div>'
+  $lightbox.css {
+    "width" :"100%",
+    "height" : "100%",
+    "position": "fixed",
+    "background-color": "rgba(0,0,0,.7)",
+    "top": 0,
+    "right": 0,
+    "bottom": 0,
+    "left": 0,
+    }
+
+  # options
+  $close = $ '<a href="#" style="position : absolute; color : #FAFAFA; top : 50px; right : 50px">X</a>'
+  $close.on 'click', (e) ->
+    $lightbox.hide()
+    $cyfullscreen.find("canvas").remove() # delete graph instances
+
+  $lightbox.append $close
+  $lightbox.hide() # hide by default
+
+  # prevent adding multiple lightboxes
+  $("body").append $lightbox if $(".lightbox").length == 0
+
+  # add a second cytoscape graph to the lightbox
+  $cyfullscreen = $ '<div class="cyfullscreen" style="position: relative; width: 80vw; height: 80vh; border: 1px solid #ccc; margin : 4% auto; background-color: #F5F5F5; padding: 10px;"></div>'
+  $lightbox.append $cyfullscreen
+
+  $fullscreenlink.on "click", (e) ->
+    e.preventDefault()
+    options.container = $cyfullscreen
+    cyfullscreen = cytoscape options
+    console.log cyfullscreen
+    $lightbox.show()
 
 bind = ($item, item) ->
   $item.dblclick -> wiki.textEditor $item, item

--- a/client/cytodemo.coffee
+++ b/client/cytodemo.coffee
@@ -51,10 +51,9 @@ elements = ($item, item) ->
 
 emit = ($item, item) ->
   $cy = $ '<div style="position: relative; width: 420px; height: 420px; border: 1px solid #ccc;"></div>'
-
   $item.append $cy
   $item.append '<p>Learn more about <a href="http://js.cytoscape.org">Cytoscape</a>.</p>'
-
+  console.log("ola cytoscape!")
   cy = cytoscape {
     container: $cy,
     layout: { name: 'dagre' },
@@ -83,6 +82,33 @@ emit = ($item, item) ->
     ]
     elements: elements($item,item)
   }
+
+
+  cy.on 'mousedown', (e) ->
+      console.log "mousedown graph"
+
+  cy.on 'tapend', (e) ->
+      console.log "tapend graph"
+
+  cy.on 'mouseup', (e) ->
+      console.log "mouseup graph"
+
+  # mouse actions
+  cy.on 'mouseover', 'edge', (e) ->
+    edge = e.cyTarget;
+    console.log "edge: %s", edge.id()
+
+  cy.on 'mouseover', 'node', (e) ->
+    node = e.cyTarget;
+    console.log "node: %s",node.id()
+
+  cy.on 'free', 'node', (e) ->
+    node = e.cyTarget;
+    console.log '%s :I am free !', node.id()
+
+  cy.on 'grab', 'node', (e) ->
+    node = e.cyTarget;
+    console.log '%s :I am grabbed...', node.id()
 
 
 bind = ($item, item) ->

--- a/client/cytodemo.coffee
+++ b/client/cytodemo.coffee
@@ -79,15 +79,20 @@ emit = ($item, item) ->
           'text-opacity': 0.5,
           'text-valign': 'center',
           'text-halign': 'right',
-          'background-color': '#11479e'
+          'background-color': '#11479e',
+          'width' : (d) ->
+            if d.degree() == 1 then 8 else d.degree()*5
+          'height' : (d) ->
+            if d.degree() == 1 then 8 else d.degree()*5
         }
       },
       {
         selector: 'edge',
         style: {
-          'width': 4,
+          'width': 2 ,
           'target-arrow-shape': 'triangle',
-          'line-color': '#9dbaea',
+          'line-color' : '#9dbaea',
+          'line-opacity': .7,
           'target-arrow-color': '#9dbaea'
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-cytodemo",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Federated Wiki - CytoDemo Plugin",
   "keywords": [
     "cytodemo",
@@ -14,7 +14,8 @@
     "url": "http://maxfranz.com"
   },
   "contributors": [
-    "Ward Cunningham"
+    "Ward Cunningham",
+    "Clément Renaud"
   ],
   "scripts": {
     "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "cytoscape": "^2.5.0",
-    "cytoscape-dagre": "^1.1.2",
-    "dagre": "^0.7.4"
+    "dagre": "^0.7.4",
+    "cytoscape-dagre": "^1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-cytodemo",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Federated Wiki - CytoDemo Plugin",
   "keywords": [
     "cytodemo",

--- a/pages/about-cytodemo-plugin
+++ b/pages/about-cytodemo-plugin
@@ -25,6 +25,11 @@
       "type": "paragraph",
       "id": "dba0455af0d0dc23",
       "text": "We use JSON formatted elements as input to the graph rendering engine. [http://js.cytoscape.org/#notation/elements-json cytoscape]"
+    },
+    {
+      "type": "paragraph",
+      "id": "868d287ecedc6c18",
+      "text": "Say any whitespace to coax the plugin to look elsewhere for graph data. (No markup means delete.) We find graph-source and merge by the same mechanism as Transport. See [[About Transport Plugin]]"
     }
   ],
   "journal": [
@@ -219,6 +224,27 @@
         "text": "Cytoscape is a graph manipulation and rendering library. We use the javascript version to demonstrate rendering that hints at the possible integrations with wiki."
       },
       "date": 1447650303315
+    },
+    {
+      "type": "add",
+      "id": "868d287ecedc6c18",
+      "item": {
+        "type": "paragraph",
+        "id": "868d287ecedc6c18",
+        "text": "Say any whitespace to coax the plugin to look elsewhere for graph data. We find graph-source and merge by the same mechanism as Transport. See [[About Transport Plugin]]"
+      },
+      "after": "dba0455af0d0dc23",
+      "date": 1465181100255
+    },
+    {
+      "type": "edit",
+      "id": "868d287ecedc6c18",
+      "item": {
+        "type": "paragraph",
+        "id": "868d287ecedc6c18",
+        "text": "Say any whitespace to coax the plugin to look elsewhere for graph data. (No markup means delete.) We find graph-source and merge by the same mechanism as Transport. See [[About Transport Plugin]]"
+      },
+      "date": 1465181131807
     }
   ]
 }


### PR DESCRIPTION
We have extended the federated wiki repertoire of plugins with a subgraph notation suitable for describing, say, an individual pattern in its upward and downward context. Browsing patterns will leave a sequence of these in the lineup. With this pull request we extend the Cytodemo plugin to recognize this collection of subgraphs, merge them into a single graph and then plot this composite with Cytoscape.

Here, for example, is Half-Hidden Garden with its successor Garden Growing Wild.

![image](https://cloud.githubusercontent.com/assets/12127/15811153/7d5aa79a-2b5a-11e6-9763-60f01bb72227.png)

Visit http://garden.asia.wiki.org/garden-patterns-inventory.html to try this yourself. Follow some sequence of patterns and then choose Lineup Viewer to see the composite graph.

You may be interested in Patterns Together to explore how collaborators can contribute related patterns and see composite paths graphed together.

This work conducted with the assistance of @opn.

We close this pull request with an overview screen of the process described above along with a sample of the batch interaction with server-side graphviz rendering of the same composite graph.

![image](https://cloud.githubusercontent.com/assets/12127/15811293/3048b7ce-2b5c-11e6-91ec-c8aa39cb7e62.png)
